### PR TITLE
Fix wheel sortings are not respected after reload game

### DIFF
--- a/GW2Radial/include/Wheel.h
+++ b/GW2Radial/include/Wheel.h
@@ -43,7 +43,7 @@ protected:
 
 	std::vector<std::unique_ptr<WheelElement>> wheelElements_;
 	bool isVisible_ = false;
-	uint minElementId_ = 0;
+	uint minElementSroting_ = 0;
 	Keybind keybind_, centralKeybind_;
 
 	ConfigurationOption<int> centerBehaviorOption_;

--- a/GW2Radial/src/Wheel.cpp
+++ b/GW2Radial/src/Wheel.cpp
@@ -234,7 +234,7 @@ void Wheel::Draw(IDirect3DDevice9* dev, ID3DXEffect* fx, UnitQuad* quad)
 					break;
 				case CenterBehavior::FAVORITE:
 					for(const auto& e : wheelElements_)
-						if(e->elementId() == minElementId_ + uint(centerFavoriteOption_.value()))
+						if(e->sortingPriority() == minElementSroting_ + uint(centerFavoriteOption_.value()))
 							hoveredFadeIns.push_back(e->hoverFadeIn(currentTime, this));
 					break;
 				default:
@@ -303,8 +303,8 @@ void Wheel::OnFocusLost()
 void Wheel::Sort()
 {
 	std::sort(wheelElements_.begin(), wheelElements_.end(),
-		[](const std::unique_ptr<WheelElement>& a, const std::unique_ptr<WheelElement>& b) { return a->elementId() < b->elementId(); });
-	minElementId_ = wheelElements_.front()->elementId();
+		[](const std::unique_ptr<WheelElement>& a, const std::unique_ptr<WheelElement>& b) { return a->sortingPriority() < b->sortingPriority(); });
+	minElementSroting_ = wheelElements_.front()->sortingPriority();
 }
 
 WheelElement* Wheel::GetCenterHoveredElement()
@@ -318,7 +318,7 @@ WheelElement* Wheel::GetCenterHoveredElement()
 		return previousUsed_;
 	case CenterBehavior::FAVORITE:
 		for(const auto& e : wheelElements_)
-			if(e->elementId() == minElementId_ + uint(centerFavoriteOption_.value()))
+			if(e->sortingPriority() == minElementSroting_ + uint(centerFavoriteOption_.value()))
 				return e.get();
 	default:
 		return nullptr;


### PR DESCRIPTION
While UI allows users to change priority and thus change the order of elements in wheels. However, original `Sort` function which used in `AddElement` is sorting elements with `elementId_`. The result is whenever user restarts game client, the orders are restored to default just like changes are not saved.

This PR fixes above issue:
1. Sort elements by `sortingPriority` in `Sort` function.
2. Rename `minElementId_` to `minElementSorting_` to better reflect the purpose of variable.
3. In `CenterBehavior::FAVORITE` case uses `sortingPriority` instead of `elementId` to determine which element should be got.
