### PR TITLE
Keybinds with modifiers bugged after recent changes

### DIFF
--- a/GW2Radial/src/Input.cpp
+++ b/GW2Radial/src/Input.cpp
@@ -343,9 +343,9 @@ Input::DelayedInput Input::TransformVKey(uint vk, bool down, mstime t, const std
 std::tuple<WPARAM, LPARAM> Input::CreateMouseEventParams(const std::optional<Point>& cursorPos) const
 {
 	WPARAM wParam = 0;
-	if (DownKeys.count(VK_LCONTROL) || DownKeys.count(VK_RCONTROL))
+	if (DownKeys.count(VK_CONTROL) || DownKeys.count(VK_LCONTROL) || DownKeys.count(VK_RCONTROL))
 		wParam += MK_CONTROL;
-	if (DownKeys.count(VK_LSHIFT) || DownKeys.count(VK_RSHIFT))
+	if (DownKeys.count(VK_SHIFT) || DownKeys.count(VK_LSHIFT) || DownKeys.count(VK_RSHIFT))
 		wParam += MK_SHIFT;
 	if (DownKeys.count(VK_LBUTTON))
 		wParam += MK_LBUTTON;
@@ -368,7 +368,7 @@ void Input::SendKeybind(const std::set<uint> &vkeys, const std::optional<Point>&
 	std::list<uint> vkeysSorted(vkeys.begin(), vkeys.end());
 	vkeysSorted.sort([](uint &a, uint &b)
 	{
-		if (std::set<uint>{ VK_LCONTROL, VK_RCONTROL, VK_LSHIFT, VK_RSHIFT, VK_LMENU, VK_RMENU }.count(a))
+		if (std::set<uint>{ VK_CONTROL, VK_LCONTROL, VK_RCONTROL, VK_SHIFT, VK_LSHIFT, VK_RSHIFT, VK_MENU, VK_LMENU, VK_RMENU }.count(a))
 			return true;
 		else
 			return a < b;


### PR DESCRIPTION
https://github.com/Friendly0Fire/GW2Radial/commit/4eb85dc5f1463d2a3a166359ea1a0474e87c2274 allowed to **optionally** distinguish left/right modifier keys, but if the option is disabled, `VK_CONTROL`, `VK_MENU`, `VK_SHIFT` are still passed instead of `VK_LCONTROL`, `VK_RCONTROL` and such. The problem lies in that `VK_CONTROL`, `VK_MENU`, `VK_SHIFT` were removed from certain checks, which now causes them to not be prioritized over other VKs, leading to keybinds executing other keys **before** ctrl/alt/shift, which completely breaks some of them. Because VKs are sorted using their value, and `VK_CONTROL`, `VK_MENU`, `VK_SHIFT` have low values of 0x10..0x12, only the keys that come before them in the VK enum are affected by the bug, namely:
- Mouse buttons (0x01..0x06)
- Backspace (0x08)
- Tab (0x09)
- Clear? (0x0C)
- Enter (0x0D)

If some keybinds were assigned these buttons along with modifiers (e.g. "Shift + MB3", "Ctrl + Alt + Backspace") - they broke as of the aforementioned commit. This PR fixes that by restoring non-distinguished VK checks.