### PR TITLE
Mention that it is Windows-only in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # GW2 Radial
 
-An [*ArenaNET-approved<sup>TM</sup>*](https://www.reddit.com/r/Guildwars2/comments/746mar/mount_radial_menu_addon_very_alpha_much_untested/dnwqj9x/) addon to show a convenient, customizable [radial menu overlay](https://giant.gfycat.com/WarpedInsistentIrishterrier.mp4) to select a mount, novelty item and more, on the fly, for *Guild Wars 2: Path of Fire*.
+An [*ArenaNET-approved<sup>TM</sup>*](https://www.reddit.com/r/Guildwars2/comments/746mar/mount_radial_menu_addon_very_alpha_much_untested/dnwqj9x/) addon to show a convenient, customizable [radial menu overlay](https://giant.gfycat.com/WarpedInsistentIrishterrier.mp4) to select a mount, novelty item and more, on the fly, for *Guild Wars 2: Path of Fire*. This addon is compatible with the Windows client only; it will not work with the Mac client.
 
 ## Installation
 - Download and extract the archive ``GW2Radial.zip`` found in the [latest release](https://github.com/Friendly0Fire/GW2Radial/releases/latest).


### PR DESCRIPTION
Since this addon relies on D3D and the Mac client uses OpenGL (and we only ship a Windows dll), this addon does not work with the Mac client. Noting this in the readme will prevent frustrated users and reports like #86.