### PR TITLE
Fixed major issue with extended keys not working as expected

### DIFF
--- a/GW2Radial/include/ScanCode.h
+++ b/GW2Radial/include/ScanCode.h
@@ -245,6 +245,19 @@ inline bool IsExtendedKey(const ScanCode& a) {
     case ScanCode::CONTROLRIGHT:
     case ScanCode::ALTRIGHT:
     case ScanCode::METARIGHT:
+    // These are also extended keys: https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-keydown#remarks
+    case ScanCode::INSERT:
+    case ScanCode::DELETE_:
+    case ScanCode::HOME:
+    case ScanCode::END:
+    case ScanCode::PAGEUP:
+    case ScanCode::PAGEDOWN:
+    case ScanCode::ARROWLEFT:
+    case ScanCode::ARROWDOWN:
+    case ScanCode::ARROWUP:
+    case ScanCode::ARROWRIGHT:
+    case ScanCode::NUMPAD_DIVIDE:
+    case ScanCode::NUMPAD_ENTER:
         return true;
     default:
         return false;

--- a/GW2Radial/src/Input.cpp
+++ b/GW2Radial/src/Input.cpp
@@ -291,7 +291,7 @@ namespace GW2Radial
             i.wParam = MapVirtualKey(uint(sc), isUniversal ? MAPVK_VSC_TO_VK : MAPVK_VSC_TO_VK_EX);
             GW2_ASSERT(i.wParam != 0);
             i.lParamKey.repeatCount = 0;
-            i.lParamKey.scanCode = uint(sc);
+            i.lParamKey.scanCode = uint(sc) & 0xFF; // Only take the first octet; there's a possibility the value won't fit in the bit field otherwise
             i.lParamKey.extendedFlag = IsExtendedKey(sc) ? 1 : 0;
             i.lParamKey.contextCode = 0;
             i.lParamKey.previousKeyState = down ? 0 : 1;

--- a/GW2Radial/src/ScanCode.cpp
+++ b/GW2Radial/src/ScanCode.cpp
@@ -3,19 +3,20 @@
 namespace GW2Radial
 {
 ScanCode GetScanCode(KeyLParam lParam) {
+    uint scanCode = lParam.scanCode;
     if (lParam.extendedFlag)
     {
-        if (lParam.scanCode != 0x45)
-            lParam.scanCode |= 0xE000;
+        if (scanCode != 0x45)
+            scanCode |= 0xE000;
     } else
     {
-        if (lParam.scanCode == 0x45)
-            lParam.scanCode = 0xE11D45;
-        else if (lParam.scanCode == 0x54)
-            lParam.scanCode = 0xE037;
+        if (scanCode == 0x45)
+            scanCode = 0xE11D45;
+        else if (scanCode == 0x54)
+            scanCode = 0xE037;
     }
 
-    return ScanCode(lParam.scanCode);
+    return ScanCode(scanCode);
 }
 
 std::wstring GetScanCodeName(ScanCode scanCode) {

--- a/GW2Radial/src/ScanCode.cpp
+++ b/GW2Radial/src/ScanCode.cpp
@@ -60,7 +60,8 @@ std::wstring GetScanCodeName(ScanCode scanCode) {
 	}
 
 	wchar_t keyName[50];
-	if (GetKeyNameTextW(uint(scanCode) << 16, keyName, int(std::size(keyName))) != 0)
+	LONG lParam = (uint(scanCode) & 0xFF) << 16 | (IsExtendedKey(scanCode) ? 1 : 0) << 24;
+	if (GetKeyNameTextW(lParam, keyName, int(std::size(keyName))) != 0)
 		return keyName;
 
 	return L"[Error]";


### PR DESCRIPTION
Basically, the message of commit aleab@04937f2 should explain the problem.
The cause of the issue is this piece of code, where a value greater than 0xFF is being assigned to the bit field `lParam.scanCode` which has a max size of 8 bits and is therefore ignoring the value (or just taking its first 8 bits).

https://github.com/Friendly0Fire/GW2Radial/blob/833b6cb30232210c345a94fe1be68c7d83ae3808/GW2Radial/src/ScanCode.cpp#L5-L19

This is all untested, since unfortunately I couldn't get the project to compile because of missing files (maybe?)
The solution references a certain _"..\GW2Radial<ins>2</ins>\GW2Radial\minhook"_ project which is not in the repo as well as a non-existent submodule commit for `ziplib` (58f83e8).

Related issue: #155