### PR TITLE
Fixes https://github.com/Friendly0Fire/GW2Radial/issues/193

### DIFF
--- a/GW2Radial/include/Keybind.h
+++ b/GW2Radial/include/Keybind.h
@@ -32,7 +32,7 @@ public:
 	[[nodiscard]] const char* keysDisplayString() const { return keysDisplayString_.data(); }
 	std::array<char, 256>& keysDisplayStringArray() { return keysDisplayString_; }
 	
-	[[nodiscard]] bool matches(const std::set<ScanCode>& scanCodes) const { return scanCodes == scanCodes_; }
+	[[nodiscard]] bool matches(const std::set<ScanCode>& scanCodes) const { return isSet() && (scanCodes == scanCodes_); }
 	[[nodiscard]] bool matchesPartial(const std::set<ScanCode>& scanCodes) const
 	{
 		return isSet() && std::includes(scanCodes.begin(), scanCodes.end(), scanCodes_.begin(), scanCodes_.end());

--- a/GW2Radial/src/Wheel.cpp
+++ b/GW2Radial/src/Wheel.cpp
@@ -651,8 +651,8 @@ InputResponse Wheel::OnInputChange(bool changed, const std::set<ScanCode>& scs, 
 		isVisible_ = false;
 	else {
 
-		bool mountOverlay = (!enableConditionsOption_.value() || keybind_.conditionsFulfilled()) && keybind_.matchesPartial(scs);
-		bool mountOverlayLocked = (!enableConditionsOption_.value() || centralKeybind_.conditionsFulfilled()) && centralKeybind_.matchesPartial(scs);
+		bool mountOverlay = (!enableConditionsOption_.value() || keybind_.conditionsFulfilled()) && keybind_.matches(scs);
+		bool mountOverlayLocked = (!enableConditionsOption_.value() || centralKeybind_.conditionsFulfilled()) && centralKeybind_.matches(scs);
 
 		WheelElement* bypassElement = nullptr;
 		if ((mountOverlayLocked || mountOverlay) && doBypassWheel_(bypassElement) && !waitingForBypassComplete_) {


### PR DESCRIPTION
Change Keybind::matches() to reject empty scan codes
Change Wheel::OnInputchange() to use Keybind;:matches() to reject M3 keybind when Shift + M3 is being pressed