### PR TITLE
Fix null pointer dereference when no mount is selected

### DIFF
--- a/GW2Radial/src/Wheel.cpp
+++ b/GW2Radial/src/Wheel.cpp
@@ -858,9 +858,11 @@ void Wheel::DeactivateWheel()
 }
 
 void Wheel::SendKeybindOrDelay(WheelElement* we, std::optional<Point> mousePos) {
-	if (we == nullptr && mousePos) {
-		Log::i().Print(Severity::Debug, "Restoring cursor position ({}, {}).", cursorResetPosition_->x, cursorResetPosition_->y);
-		Input::i().SendKeybind({}, mousePos);
+	if (we == nullptr) {
+		if (mousePos) {
+			Log::i().Print(Severity::Debug, "Restoring cursor position ({}, {}).", cursorResetPosition_->x, cursorResetPosition_->y);
+			Input::i().SendKeybind({}, mousePos);
+		}
 		return;
 	}
 


### PR DESCRIPTION
When the "Move cursor to original location after release" option is disabled, releasing the keybind without selecting a mount dereferences a null pointer and causes the game to crash. The crash happens in `Wheel::SendKeybindOrDelay()` on line 885 (when `we` is null and `mousePos` is not set):

https://github.com/Friendly0Fire/GW2Radial/blob/2cd4063987739fca830a96a2cf0b0512bc6ff6ac/GW2Radial/src/Wheel.cpp#L860-L887

Not being familiar with the code, it seemed reasonable to me to just have the null check at the top of the function catch both cases (where the cursor should/shouldn't reset to the previous position). If there's another place where this check would make more sense, let me know.

Fixes #244
Fixes #247 